### PR TITLE
Закрытие заказа

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1119,6 +1119,23 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "status": {
+                    "enum": [
+                        "beginning",
+                        "negotiation",
+                        "budgeting",
+                        "work",
+                        "reviews",
+                        "finished",
+                        "dispute"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/github_com_moevm_nosql1h25-writer_backend_internal_entity.StatusType"
+                        }
+                    ],
+                    "example": "finished"
+                },
                 "title": {
                     "type": "string",
                     "maxLength": 256,

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1113,6 +1113,23 @@
                 "id": {
                     "type": "string"
                 },
+                "status": {
+                    "enum": [
+                        "beginning",
+                        "negotiation",
+                        "budgeting",
+                        "work",
+                        "reviews",
+                        "finished",
+                        "dispute"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/github_com_moevm_nosql1h25-writer_backend_internal_entity.StatusType"
+                        }
+                    ],
+                    "example": "finished"
+                },
                 "title": {
                     "type": "string",
                     "maxLength": 256,

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -226,6 +226,18 @@ definitions:
         type: string
       id:
         type: string
+      status:
+        allOf:
+        - $ref: '#/definitions/github_com_moevm_nosql1h25-writer_backend_internal_entity.StatusType'
+        enum:
+        - beginning
+        - negotiation
+        - budgeting
+        - work
+        - reviews
+        - finished
+        - dispute
+        example: finished
       title:
         example: New title
         maxLength: 256

--- a/backend/internal/api/patch_orders_id/handler.go
+++ b/backend/internal/api/patch_orders_id/handler.go
@@ -28,6 +28,7 @@ type Request struct {
 	Description    *string            `json:"description,omitempty" validate:"omitempty,min=16,max=2048" example:"New Order Description"`
 	CompletionTime *int64             `json:"completionTime,omitempty" validate:"omitempty,gte=3600000000000" example:"3600000000000"`
 	Cost           *int               `json:"cost,omitempty" validate:"omitempty,min=0" example:"5000"`
+	Status         *entity.StatusType `json:"status,omitempty" validate:"omitempty,oneof=beginning negotiation budgeting work reviews finished dispute" example:"finished"`
 }
 
 // Handle - Update order
@@ -52,7 +53,7 @@ func (h *handler) Handle(c echo.Context, in Request) error {
 	userID := c.Get(mw.UserIDKey).(primitive.ObjectID)      //nolint:forcetypeassert
 
 	// Проверка: если не передано ни одного изменяемого поля
-	if in.Title == nil && in.Description == nil && in.CompletionTime == nil && in.Cost == nil {
+	if in.Title == nil && in.Description == nil && in.CompletionTime == nil && in.Cost == nil && in.Status == nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "no fields to update")
 	}
 
@@ -78,6 +79,7 @@ func (h *handler) Handle(c echo.Context, in Request) error {
 		Description:    in.Description,
 		CompletionTime: in.CompletionTime,
 		Cost:           in.Cost,
+		Status:         in.Status,
 	})
 	if err != nil {
 		if errors.Is(err, orders.ErrOrderNotFound) {

--- a/backend/internal/repo/orders/dto.go
+++ b/backend/internal/repo/orders/dto.go
@@ -1,6 +1,9 @@
 package orders
 
-import "go.mongodb.org/mongo-driver/bson/primitive"
+import (
+	"github.com/moevm/nosql1h25-writer/backend/internal/entity"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
 
 type FindOut struct {
 	Orders []OrderWithClientData
@@ -32,4 +35,5 @@ type UpdateIn struct {
 	Description    *string
 	CompletionTime *int64
 	Cost           *int
+	Status         *entity.StatusType
 }

--- a/backend/internal/service/orders/dto.go
+++ b/backend/internal/service/orders/dto.go
@@ -1,6 +1,9 @@
 package orders
 
-import "go.mongodb.org/mongo-driver/bson/primitive"
+import (
+	"github.com/moevm/nosql1h25-writer/backend/internal/entity"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
 
 type CreateIn struct {
 	ClientID       primitive.ObjectID
@@ -32,4 +35,5 @@ type UpdateIn struct {
 	Description    *string
 	CompletionTime *int64
 	Cost           *int
+	Status         *entity.StatusType
 }

--- a/backend/internal/service/orders/service.go
+++ b/backend/internal/service/orders/service.go
@@ -92,6 +92,7 @@ func (s *service) Update(ctx context.Context, in UpdateIn) error {
 		Description:    in.Description,
 		CompletionTime: in.CompletionTime,
 		Cost:           in.Cost,
+		Status:         in.Status,
 	})
 	if err != nil {
 		if errors.Is(err, orders.ErrOrderNotFound) {


### PR DESCRIPTION
Модифицировал **`patch_orders_id`**:
- Добавлен опциональный аргумент: `Status`, который пушится в конец массива статусов соответствующего заказа
- Пушит только статус, с допустимым именем:
```
- beginning
- negotiation
- budgeting
- work
- reviews
- finished
- dispute
```
- Права доступа: только создатель заказа и администратор